### PR TITLE
coerce falsey values in BooleanPacker

### DIFF
--- a/lib/bank/serialize.rb
+++ b/lib/bank/serialize.rb
@@ -29,7 +29,9 @@ module Bank
 
     PackBooleans = ->(attrs, config) do
       config.columns_of_type(:boolean).each { |column, opts|
-        attrs[column] = attrs[column] ? 1 : 0
+        false_values = [false, nil, 0, 'false', 'nil', '0']
+        value = !false_values.include?(attrs[column])
+        attrs[column] = value ? 1 : 0
       }
     end
 

--- a/spec/acceptance/bank_spec.rb
+++ b/spec/acceptance/bank_spec.rb
@@ -76,6 +76,33 @@ describe Bank, "Acceptance" do
       expect(saved_model.age).to eq 50
     end
 
+    describe "coerces params to booleans if need be" do
+      def expect_verified_to_be_false(value)
+        saved_model = collection.create(:verified => value)
+        expect(saved_model.verified).to be_false
+      end
+
+      it "with false string" do
+        expect_verified_to_be_false("false")
+      end
+
+      it "with nil string" do
+        expect_verified_to_be_false("nil")
+      end
+
+      it "with zero string" do
+        expect_verified_to_be_false("0")
+      end
+
+      it "with nil" do
+        expect_verified_to_be_false(nil)
+      end
+
+      it "with 0" do
+        expect_verified_to_be_false(0)
+      end
+    end
+
     it "sets a created_at on create" do
       now = Time.at(Time.now.to_i)
       Time.stub(:now) { now }
@@ -231,10 +258,10 @@ describe Bank, "Acceptance" do
 
     it "converts booleans" do
       falsey = collection.create(:verified => false)
-      expect(collection.find(falsey.id).verified).to be_falsey
+      expect(collection.find(falsey.id).verified).to be_false
 
       truthy = collection.create(:verified => true)
-      expect(collection.find(truthy.id).verified).to be_truthy
+      expect(collection.find(truthy.id).verified).to be_true
     end
 
   end


### PR DESCRIPTION
- use `be_true` and `be_false` in place of `be_truthy` and `be_falsey` since gemspec specifies rspec 2.14